### PR TITLE
Fix torctl-autostart error 'already started'. Closes #21

### DIFF
--- a/torctl
+++ b/torctl
@@ -418,7 +418,9 @@ apply_sysctl_rules() {
 start() {
     # check if started
     if is_started; then
-        err "torctl is already started"
+        # err "torctl is already started"
+        # Fix torctl-autostart error 'already started'
+        stop
     fi
 
     # backup torrc


### PR DESCRIPTION
Hi! I have been using torctl for 1 year now, and up to this point I have always fixed this error locally, at home. But now I want torctl to already be working right from pacman.

![image](https://github.com/BlackArch/torctl/assets/72896991/7e2a2a21-a8a8-4b7b-9524-ebd4e7bcc651)
